### PR TITLE
Feat: 공통 레이아웃 컴포넌트 추가

### DIFF
--- a/app/_components/common-layout/index.tsx
+++ b/app/_components/common-layout/index.tsx
@@ -1,0 +1,15 @@
+import type { PropsWithChildren } from 'react';
+
+interface CommonLayoutProps extends PropsWithChildren {
+  className?: string;
+}
+
+function CommonLayout({ children, className }: CommonLayoutProps) {
+  return (
+    <div className="mx-auto w-full max-w-[1248px] px-4 mobile:px-6">
+      <div className={`commonLayoutWrap ${className}`}>{children}</div>
+    </div>
+  );
+}
+
+export default CommonLayout;

--- a/app/_components/side-sticky-layout/index.tsx
+++ b/app/_components/side-sticky-layout/index.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import type { PropsWithChildren } from 'react';
+import { useEffect, useState } from 'react';
+
+import useWindowSize from '@/_hooks/useWindowSize';
+
+/**
+ * 왼쪽 내정보 사이드 메뉴 고정된 레이아웃
+ */
+function StickyLayout({ children }: PropsWithChildren) {
+  const windowSize = useWindowSize();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (windowSize !== null) {
+      setIsLoading(false);
+    }
+  }, [windowSize]);
+
+  const isPC = windowSize > 768;
+
+  return (
+    <div className="flex gap-6">
+      {isLoading ? (
+        <section className="sticky top-20 hidden h-fit max-w-[384px] flex-1 rounded-xl bg-slate-300 p-6 tablet:block">
+          {/* 스켈레톤 UI */}
+          <div className="animate-pulse">
+            <div className="h-6 rounded bg-gray-300" />
+          </div>
+        </section>
+      ) : (
+        isPC && <section className="sticky top-20 h-fit max-w-[384px] flex-1 rounded-xl bg-slate-300 p-6">사이드 스티키 메뉴</section>
+      )}
+      <section className="min-w-[430px] flex-1">{children}</section>
+    </div>
+  );
+}
+
+export default StickyLayout;

--- a/app/_hooks/useWindowSize.ts
+++ b/app/_hooks/useWindowSize.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { debounce } from 'lodash';
+
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState(0);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize(window.innerWidth);
+    };
+
+    handleResize();
+    const debouncedHandleResize = debounce(handleResize, 300);
+    window.addEventListener('resize', debouncedHandleResize);
+    return () => window.removeEventListener('resize', debouncedHandleResize);
+  }, []);
+
+  return windowSize;
+};
+
+export default useWindowSize;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "^5.51.11",
     "@tanstack/react-query-devtools": "^5.51.11",
     "axios": "^1.7.2",
+    "lodash": "^4.17.21",
     "next": "14.2.5",
     "pretendard": "^1.3.9",
     "react": "^18",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
+    "@types/lodash": "^4.17.7",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -42,4 +42,7 @@
   h3 {
     @apply text-l font-bold;
   }
+  .commonLayoutWrap {
+    @apply pb-[136px] pt-6 mobile:pb-[312px] tablet:pb-[344px] tablet:pt-[72px];
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,10 +845,22 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@*", "@types/node@^20":
-  version "20.14.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.12.tgz#129d7c3a822cb49fc7ff661235f19cfefd422b49"
-  integrity sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==
+"@types/lodash@^4.17.7":
+  version "4.17.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.7.tgz#2f776bcb53adc9e13b2c0dfd493dfcbd7de43612"
+  integrity sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==
+
+"@types/node@*":
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.0.0.tgz#04862a2a71e62264426083abe1e27e87cac05a30"
+  integrity sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==
+  dependencies:
+    undici-types "~6.11.1"
+
+"@types/node@^20":
+  version "20.14.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.13.tgz#bf4fe8959ae1c43bc284de78bd6c01730933736b"
+  integrity sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==
   dependencies:
     undici-types "~5.26.4"
 
@@ -3527,6 +3539,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 <!-- 이슈 번호 입력 -->

- close #22 

## 🧱 작업 사항
- 콘텐츠 최대 너비, 가운데 맞춤, 반응형 좌우 패딩 적용한 공통 레이아웃 컴포넌트 작업
- 사이드 메뉴 레이아웃 작업했습니다. (pc에서만 사이드 메뉴 노출, 스크롤시 스티키)

## 📸 결과물
![image](https://github.com/user-attachments/assets/1e201c47-9bf1-4ea9-ab8f-871c04f57312)
![image](https://github.com/user-attachments/assets/969fcea0-3692-4193-b03b-0bf6536bcc28)


## 💬 공유 포인트 및 논의 사항
- 페이지 별로 상하 패딩 값이 달라서 CommonLayout에 클래스명으로 상하 패딩값 줘서 덮어쓰면 됩니다!
- 로그인, 회원가입 페이지에서는 사용 불가능합니다
- 메인 페이지에서는 배너 아래 영역에 적용하는 식으로 활용해야할 것 같아요
- 사용방법
  ```ts
  <CommonLayout className="pb-[30px]">
    // 코드
  </CommonLayout>

  <CommonLayout>
    <StickyLayout>
      // 코드
    </StickyLayout>
  </CommonLayout>
  ```