### PR TITLE
Chore: 폰트 시스템 개편

### DIFF
--- a/styles/tailwind.typography.ts
+++ b/styles/tailwind.typography.ts
@@ -1,20 +1,24 @@
 const typography = {
   fontFamily: {
-    Pretendard: ['Pretendard Variable', 'Pretendard', 'sans-serif'],
-    SpoqaHanSans: ['SpoqaHanSansNeo-Regular', 'sans-serif'],
-    Inter: ['Inter', 'sans-serif'],
+    pretendard: ['Pretendard Variable', 'Pretendard', 'sans-serif'],
+    spoqaHanSans: ['SpoqaHanSansNeo-Regular', 'sans-serif'],
+    inter: ['Inter', 'sans-serif'],
   },
   fontSize: {
-    's': '12px',
-    'm': '14px',
-    'base': '16px',
-    'ml': '18px',
-    'l': '20px',
-    'xl': '24px',
-    '2xl': '28px',
-    '3xl': '32px',
-    '4xl': '36px',
-    '6xl': '68px',
+    'xs': ['12px', { lineHeight: '18px' }],
+    'sm': ['13px', { lineHeight: '22px' }],
+    'md': ['14px', { lineHeight: '24px' }],
+    'lg': ['16px', { lineHeight: '26px' }],
+    '2lg': ['18px', { lineHeight: '26px' }],
+    'xl': ['20px', { lineHeight: '32px' }],
+    '2xl': ['24px', { lineHeight: '32px' }],
+    '3xl': ['32px', { lineHeight: '42px' }],
+  },
+  fontWeight: {
+    bold: 700,
+    semibold: 600,
+    medium: 500,
+    regular: 400,
   },
 };
 


### PR DESCRIPTION
## 🏷️ 이슈 번호 

- close #32 

## 🧱 작업 사항
- 폰트 시스템을 피그마에 있는 형식으로 개편하였습니다.

## 📸 결과물
![image](https://github.com/user-attachments/assets/1f83eab0-bc4b-4d9e-a749-6895b4715ff9)

## 💬 공유 포인트 및 논의 사항
- 다음 리팩토링 시간 (다음 주 월요일, 8월 12일)에 기존 폰트 사용을 모두 리팩토링하면 어떨까요?